### PR TITLE
Update image_build_push.yaml

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: ""
+      USE_QUAY_ONLY:
+        required: false
+        type: boolean
+        default: false
     secrets:
       ECR_AWS_ACCESS_KEY_ID:
         required: true
@@ -97,6 +101,7 @@ jobs:
           fi
 
       - name: Build and push
+        if: ${{ !inputs.USE_QUAY_ONLY }}
         uses: docker/build-push-action@v2
         with:
           context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
@@ -107,3 +112,13 @@ jobs:
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           cache-from: type=registry,ref=${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           cache-to: type=inline
+          
+      - name: Build and push (Quay only)
+        if: ${{ inputs.USE_QUAY_ONLY }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
+          file: ${{ inputs.DOCKERFILE_LOCATION }}
+          push: true
+          tags: |
+            quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -122,3 +122,5 @@ jobs:
           push: true
           tags: |
             quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
+          cache-from: type=registry,ref=quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
+          cache-to: type=inline


### PR DESCRIPTION
New input arg `USE_QUAY_ONLY` to only build and push images to quay.io but not ECR. It is easier to create and config a quay image repo for a GH repo, especially if the code are experimental and not being delopyed to prod envs


### Improvements
- New input arg `USE_QUAY_ONLY` to only build and push images to quay.io but not ECR

