### PR TITLE
using default GITHUB_TOKEN that is automatically pre-filled by github

### DIFF
--- a/.github/workflows/golang-ci-workflow.yaml
+++ b/.github/workflows/golang-ci-workflow.yaml
@@ -11,9 +11,6 @@ on:
         required: false
         type: string
         default: "./..."
-    secrets:
-      REPO_GITHUB_TOKEN:
-        required: true
 
 jobs:
   test:
@@ -60,5 +57,5 @@ jobs:
         run: go install github.com/mattn/goveralls@latest
       - name: Send coverage
         env:
-          COVERALLS_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=./profile.cov -service=github


### PR DESCRIPTION
see https://docs.github.com/en/actions/security-guides/automatic-token-authentication

Jira Ticket: part of [PXP-9660](https://ctds-planx.atlassian.net/browse/PXP-9660)

### Improvements

- This should (hopefully) allow this reusable workflow to be used by a composite action if necessary