### PR TITLE
Golang CI: improve linting output

### DIFF
--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -48,6 +48,7 @@ runs:
         # skip-build-cache: true
     - name: Display lint results
       run: golangci-lint run
+      if: always()
       shell: bash
     - name: Run Unit tests
       id: unit_tests_step

--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -46,6 +46,8 @@ runs:
         # skip-pkg-cache: true
         # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         # skip-build-cache: true
+    - name: Display lint results
+      run: golangci-lint run
     - name: Run Unit tests
       id: unit_tests_step
       run: |

--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -48,6 +48,7 @@ runs:
         # skip-build-cache: true
     - name: Display lint results
       run: golangci-lint run
+      shell: bash
     - name: Run Unit tests
       id: unit_tests_step
       run: |


### PR DESCRIPTION
Golang CI workflow: add workaround to display the file and line in addition to the linting error so we know what to fix

See [this thread](https://github.com/golangci/golangci-lint-action/issues/362) for context

Before:
<img width="937" alt="Screen Shot 2022-06-02 at 4 30 46 PM" src="https://user-images.githubusercontent.com/4224001/171742001-6b677fcf-cdcb-47df-9514-f807e587f180.png">

After:
<img width="718" alt="Screen Shot 2022-06-02 at 4 30 54 PM" src="https://user-images.githubusercontent.com/4224001/171742019-20fbd7cd-aaf4-4d04-aaeb-c89f711df14f.png">

### Improvements
- Golang CI: improve linting output
