### PR TITLE
Golang CI: run unit tests before linting

### DIFF
--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -28,6 +28,11 @@ runs:
       run: |
         go mod download
       shell: bash
+    - name: Run Unit tests
+      id: unit_tests_step
+      run: |
+        go test ${{ inputs.TESTS_LOCATION }} -v -coverpkg=${{ inputs.TESTS_LOCATION }} -race -covermode atomic -coverprofile=${{ inputs.COVERAGE_PROFILE_OUTPUT_LOCATION }}
+      shell: bash
     - name: Lint source code
       uses: golangci/golangci-lint-action@v3
       with:
@@ -49,11 +54,6 @@ runs:
     - name: Display lint results
       run: golangci-lint run
       if: always()
-      shell: bash
-    - name: Run Unit tests
-      id: unit_tests_step
-      run: |
-        go test ${{ inputs.TESTS_LOCATION }} -v -coverpkg=${{ inputs.TESTS_LOCATION }} -race -covermode atomic -coverprofile=${{ inputs.COVERAGE_PROFILE_OUTPUT_LOCATION }}
       shell: bash
     - name: Install goveralls
       run: go install github.com/mattn/goveralls@latest


### PR DESCRIPTION
Sometimes we just want to run tests on a WIP branch without spending time fixing linting errors

### Improvements
- Golang CI: run unit tests before linting
