### PR TITLE
PXP-10371 Support user.yaml CI for forks

### DIFF
--- a/.github/workflows/user_yaml_ci.yaml
+++ b/.github/workflows/user_yaml_ci.yaml
@@ -20,6 +20,21 @@ jobs:
     name: Test and deploy
     runs-on: ubuntu-latest
     steps:
+    - name: Check PR
+      run: |
+        echo Event name: ${{ github.event_name }}
+        if [[ ${{ github.event_name }} = "pull_request" || ${{ github.event_name }} = "pull_request_target" ]]; then
+          is_fork=`curl --header "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.event.repository.full_name }}/pulls/${{github.event.number}} | jq -r .head.repo.fork`
+          echo Is this a fork? $is_fork
+          if [ $is_fork = "true" ]; then
+            labels=`curl -s --header "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.event.repository.full_name }}/issues/${{github.event.number}}/labels | jq -r '.[].name'`
+            echo Labels: $labels
+            if [[ ! " ${labels[*]} " =~ "safe to test" ]]; then
+              echo "ERROR: PRs from forks must be labeled with 'safe to test' to run the CI"
+              exit 1
+            fi
+          fi
+        fi
     - name: Set up Python
       uses: actions/setup-python@v2.3.1
       with:

--- a/.github/workflows/user_yaml_ci.yaml
+++ b/.github/workflows/user_yaml_ci.yaml
@@ -20,10 +20,6 @@ jobs:
     name: Test and deploy
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v2.3.1
       with:
@@ -32,8 +28,22 @@ jobs:
       run: |
         pip install gen3users
         pip install pyyaml==5.4
-    - name: Lint files
+    - name: Checkout, lint and test
       run: |
+        # checkout the code - this supports checking out from a private fork
+        git clone https://Bot:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.repository.full_name }}
+        cd ${{ github.event.repository.name }}
+        if [ ${{ github.event_name }} = "push" ]; then
+          branch=${GITHUB_REF##*/}
+          echo Push event: checking out branch $branch
+          git checkout $branch
+        else # this is a pull request
+          echo Pull request event: checking out branch from PR ${{github.event.number}}
+          git fetch origin pull/${{github.event.number}}/head:localbranch
+          git checkout localbranch
+        fi
+
+        # lint the files
         cat - > lint.py <<EOM
         import os
         import yaml
@@ -50,8 +60,9 @@ jobs:
         EOM
         python lint.py
         rm lint.py
-    - name: Run tests
-      run: gen3users validate users/*/user.yaml
+
+        # run the tests
+        gen3users validate users/*/user.yaml
     - name: Install AWS CLI
       if: github.ref == 'refs/heads/master'
       uses: chrislennon/action-aws-cli@1.1


### PR DESCRIPTION
Jira Ticket: [PXP-10371](https://ctds-planx.atlassian.net/browse/PXP-10371)

Use our own git logic to check out the code instead of `actions/checkout` so we can support forks.
Note that for public repos, we could use `actions/checkout` with:
```
      with:
        ref: ${{github.event.pull_request.head.ref}}
        repository: ${{github.event.pull_request.head.repo.full_name}}
```
but that doesn't work when the fork is private (since our user.yaml repos are private, the forks are too)

### New Features
- Support user.yaml CI for forks. PRs from forks will need to be labeled "safe to test" by a maintainer for the CI to run
