### PR TITLE
Test/self hosted runners

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,13 +78,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge,namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
+          driver-opts: nodeselector="kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
               driver-opts:
-              - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
+              - nodeselector="kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
               - namespace=self-hosted-runners
               - requests.cpu=7
               - requests.memory=14G

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,14 +78,16 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: nodeselector=kubernetes.io/arch=amd64,namespace=self-hosted-runners
+          driver-opts: nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge,namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
               driver-opts:
-              - nodeselector=kubernetes.io/arch=arm64
+              - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
               - namespace=self-hosted-runners
+              - requests.cpu=7
+              - requests.memory=14G
 
       - name: Set Variables
         shell: bash

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,6 +82,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
+              name: k8s-arm
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64
 

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -76,6 +76,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: kubernetes
+          driver-opts: |
+            nodeselector=kubernetes.io/arch=amd64
+          platforms: linux/amd64
+          append: |
+            name: k8s
+            driver-opts: |
+              nodeselector=kubernetes.io/arch=arm64
+            platforms: linux/arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           driver: kubernetes
           name: k8s-amd
-          driver-opts: nodeselector=kubernetes.io/arch=amd64, namespace=self-hosted-runners
+          driver-opts: nodeselector=kubernetes.io/arch=amd64,namespace=self-hosted-runners
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-            driver-opts: nodeselector=kubernetes.io/arch=arm64
+              driver-opts: nodeselector=kubernetes.io/arch=arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -84,10 +84,7 @@ jobs:
             - platforms: linux/arm64
               name: k8s-arm
               driver-opts:
-              - \"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge\"
-              - namespace=self-hosted-runners
-              - requests.cpu=7
-              - requests.memory=14G
+              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=7,requests.memory=14G
 
       - name: Set Variables
         shell: bash

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,13 +78,11 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: |
-            nodeselector=kubernetes.io/arch=amd64
+          driver-opts: nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-            - driver-opts: |
-              nodeselector=kubernetes.io/arch=arm64
+            driver-opts: nodeselector=kubernetes.io/arch=arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,6 +78,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
+          name: k8s-amd
           driver-opts: nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -87,9 +87,6 @@ jobs:
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
       - name: Set Variables
         shell: bash
         run: |

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              name: k8s-arm"
+              name: k8s-arm
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
               - namespace=self-hosted-runners

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              driver-opts: nodeselector=kubernetes.io/arch=arm64
+              driver-opts: "nodeselector=kubernetes.io/arch=arm64"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,8 @@ jobs:
             nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
-            - driver-opts: nodeselector=kubernetes.io/arch=arm64
+            - driver-opts: |
+              nodeselector=kubernetes.io/arch=arm64
             - platforms: linux/arm64
 
       - name: Set up QEMU

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,9 +82,9 @@ jobs:
             nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
+            - platforms: linux/arm64
             - driver-opts: |
               nodeselector=kubernetes.io/arch=arm64
-            - platforms: linux/arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: ""
+      OVERRIDE_BUILDER_NAME:
+        required: false
+        type: string
+        default: ""
       USE_QUAY_ONLY:
         required: false
         type: boolean
@@ -82,7 +86,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              name: k8s-arm
+              name: k8s-arm${{ inputs.OVERRIDE_BUILDER_NAME }}
               driver-opts:
               - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G
 

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,12 +78,11 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          name: k8s-amd
           driver-opts: nodeselector=kubernetes.io/arch=amd64,namespace=self-hosted-runners
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              name: k8s-arm
+              name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64
               - namespace=self-hosted-runners

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,7 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
+              name: k8s-arm"
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
               - namespace=self-hosted-runners

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,8 +82,7 @@ jobs:
             nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
-            driver-opts: |
-              nodeselector=kubernetes.io/arch=arm64
+            driver-opts: nodeselector=kubernetes.io/arch=arm64
             platforms: linux/arm64
 
       - name: Set up QEMU

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,6 @@ jobs:
             nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
-            name: k8s
             driver-opts: |
               nodeselector=kubernetes.io/arch=arm64
             platforms: linux/arm64

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -122,7 +122,7 @@ jobs:
             quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
 
-      - name: Build and push
+      - name: Build and push ECR
         if: ${{ !inputs.USE_QUAY_ONLY }}
         uses: docker/build-push-action@v3
         with:
@@ -130,14 +130,13 @@ jobs:
           file: ${{ inputs.DOCKERFILE_LOCATION }}
           push: true
           tags: |
-            quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           cache-to: type=inline
           platforms: ${{ inputs.BUILD_PLATFORMS }}
 
-      - name: Build and push (Quay only)
+      - name: Build and push Quay
         if: ${{ inputs.USE_QUAY_ONLY }}
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,7 +82,8 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              driver-opts: "nodeselector=kubernetes.io/arch=arm64"
+              driver-opts: |
+                nodeselector=kubernetes.io/arch=arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -84,7 +84,7 @@ jobs:
             - platforms: linux/arm64
               name: k8s-arm
               driver-opts:
-              - "nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
+              - \"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge\"
               - namespace=self-hosted-runners
               - requests.cpu=7
               - requests.memory=14G

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -48,7 +48,7 @@ on:
 jobs:
   ci:
     name: Build Image and Push
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       # https://github.com/docker/login-action#quayio
       - name: Login to Quay.io

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,13 +78,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: nodeselector="kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
+          driver-opts: "nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
               driver-opts:
-              - nodeselector="kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
+              - "nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
               - namespace=self-hosted-runners
               - requests.cpu=7
               - requests.memory=14G

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -84,7 +84,7 @@ jobs:
             - platforms: linux/arm64
               name: k8s-arm
               driver-opts:
-              - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
+              - "nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
               - namespace=self-hosted-runners
               - requests.cpu=7
               - requests.memory=14G

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,8 +82,8 @@ jobs:
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
-              driver-opts: |
-                nodeselector=kubernetes.io/arch=arm64
+              driver-opts:
+              - nodeselector=kubernetes.io/arch=arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -82,8 +82,8 @@ jobs:
             nodeselector=kubernetes.io/arch=amd64
           platforms: linux/amd64
           append: |
-            driver-opts: nodeselector=kubernetes.io/arch=arm64
-            platforms: linux/arm64
+            - driver-opts: nodeselector=kubernetes.io/arch=arm64
+            - platforms: linux/arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -79,13 +79,14 @@ jobs:
         with:
           driver: kubernetes
           name: k8s-amd
-          driver-opts: nodeselector=kubernetes.io/arch=amd64
+          driver-opts: nodeselector=kubernetes.io/arch=amd64, namespace=self-hosted-runners
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm
               driver-opts:
               - nodeselector=kubernetes.io/arch=arm64
+              - namespace=self-hosted-runners
 
       - name: Set Variables
         shell: bash

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,13 +78,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: "nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",namespace=self-hosted-runners,requests.cpu=7,requests.memory=29G
+          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=7,requests.memory=29G
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm-${{ inputs.OVERRIDE_TAG_NAME }}"
               driver-opts:
-              - "nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge"
+              - nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge
               - namespace=self-hosted-runners
               - requests.cpu=7
               - requests.memory=14G

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -78,13 +78,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=7,requests.memory=29G
+          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm
               driver-opts:
-              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=7,requests.memory=14G
+              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G
 
       - name: Set Variables
         shell: bash

--- a/.github/workflows/self_hosted_build_push.yaml
+++ b/.github/workflows/self_hosted_build_push.yaml
@@ -82,13 +82,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G,"key=role,value=armrunners,effect=NoSchedule"
+          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G,"tolerations=key=role,value=armrunners,effect=NoSchedule"
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm${{ inputs.OVERRIDE_BUILDER_NAME }}
               driver-opts:
-              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G,"key=role,value=armrunners,effect=NoSchedule"
+              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G,"tolerations=key=role,value=armrunners,effect=NoSchedule"
 
       - name: Set Variables
         shell: bash

--- a/.github/workflows/self_hosted_build_push.yaml
+++ b/.github/workflows/self_hosted_build_push.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: ""
+      OVERRIDE_BUILDER_NAME:
+        required: false
+        type: string
+        default: ""
       USE_QUAY_ONLY:
         required: false
         type: boolean
@@ -48,7 +52,7 @@ on:
 jobs:
   ci:
     name: Build Image and Push
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       # https://github.com/docker/login-action#quayio
       - name: Login to Quay.io
@@ -76,9 +80,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        with:
+          driver: kubernetes
+          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G
+          platforms: linux/amd64
+          append: |
+            - platforms: linux/arm64
+              name: k8s-arm${{ inputs.OVERRIDE_BUILDER_NAME }}
+              driver-opts:
+              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G
 
       - name: Set Variables
         shell: bash
@@ -116,34 +126,30 @@ jobs:
             quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
 
-      - name: Build and push
+      - name: Build and push ECR
         if: ${{ !inputs.USE_QUAY_ONLY }}
         uses: docker/build-push-action@v3
-        # You may get ECR-push errors when first adding the workflow to a github repo.
-        # If so, run the following in dev/qa to create the ECR repository:
-        # qaplanetv1@cdistest_dev_admin:~$ aws ecr create-repository --repository-name "gen3/<repo name>" --image-scanning-configuration scanOnPush=true
         with:
           context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
           file: ${{ inputs.DOCKERFILE_LOCATION }}
           push: true
           tags: |
-            quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
           cache-to: type=inline
           platforms: ${{ inputs.BUILD_PLATFORMS }}
 
-      - name: Build and push (Quay only)
-        if: ${{ inputs.USE_QUAY_ONLY }}
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
-          file: ${{ inputs.DOCKERFILE_LOCATION }}
-          push: true
-          tags: |
-            quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
-          cache-to: type=inline
-          platforms: ${{ inputs.BUILD_PLATFORMS }}
+#      - name: Build and push Quay
+#        if: ${{ inputs.USE_QUAY_ONLY }}
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
+#          file: ${{ inputs.DOCKERFILE_LOCATION }}
+#          push: true
+#          tags: |
+#            quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
+#          labels: ${{ steps.meta.outputs.labels }}
+#          cache-from: type=registry,ref=quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
+#          cache-to: type=inline
+#          platforms: ${{ inputs.BUILD_PLATFORMS }}

--- a/.github/workflows/self_hosted_build_push.yaml
+++ b/.github/workflows/self_hosted_build_push.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build and push ECR
         if: ${{ !inputs.USE_QUAY_ONLY }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}
           file: ${{ inputs.DOCKERFILE_LOCATION }}

--- a/.github/workflows/self_hosted_build_push.yaml
+++ b/.github/workflows/self_hosted_build_push.yaml
@@ -82,13 +82,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver: kubernetes
-          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G
+          driver-opts: namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=amd64,node.kubernetes.io/instance-type=t3.2xlarge",requests.cpu=6,requests.memory=25G,"key=role,value=armrunners,effect=NoSchedule"
           platforms: linux/amd64
           append: |
             - platforms: linux/arm64
               name: k8s-arm${{ inputs.OVERRIDE_BUILDER_NAME }}
               driver-opts:
-              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G
+              - namespace=self-hosted-runners,"nodeselector=kubernetes.io/arch=arm64,node.kubernetes.io/instance-type=c7g.2xlarge",requests.cpu=6,requests.memory=10G,"key=role,value=armrunners,effect=NoSchedule"
 
       - name: Set Variables
         shell: bash


### PR DESCRIPTION
### New Features
Created a self hosted runner workflow that builds on amd/arm nodes natively so that we can have arm images run without the need for emulation through qemu/binfmt. The runners are on dev2 and need to be setup manually for each repo.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
