### PR TITLE
upgrade golangci-lint to 1.5x

### DIFF
--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -37,7 +37,7 @@ runs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.45
+        version: v1.51.2
         # Optional: working directory, useful for monorepos
         # working-directory: somedir
         # Optional: golangci-lint command line arguments.


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
Upgrade golanci-lint to 1.5x. 

We were running into this issue in hatchery: https://github.com/golangci/golangci-lint/issues/3107 

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
