### PR TITLE
Chore - removing Superlint for now

### DIFF
--- a/.github/workflows/securitypipeline.yaml
+++ b/.github/workflows/securitypipeline.yaml
@@ -9,22 +9,6 @@ on:
         default: 'true'
 
 jobs:
-  # Superlint a simple combination of various linters, written in bash, to help validate source code.
-  Superlint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Lint Repo
-        uses: github/super-linter/slim@v4
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Secrets detection is calling the Yelp Secrets Detector we use in pre-commit to ensure proper coverage
   secrets-detection:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Removing Superlint from the security pipeline as it is currently failing on a regular basis.  To be re-assessed later. 
