### PR TITLE
Do not push to S3 for event 'pull_request_target'

### DIFF
--- a/.github/workflows/user_yaml_ci.yaml
+++ b/.github/workflows/user_yaml_ci.yaml
@@ -89,10 +89,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install AWS CLI
-      if: github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: chrislennon/action-aws-cli@1.1
     - name: Deploy to S3
-      if: github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         cd ${{ github.event.repository.name }}
         aws s3 cp users s3://${{ inputs.BUCKET }}/ --recursive --region ${{ inputs.REGION }}


### PR DESCRIPTION
According to the [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context):
> For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch. [...] For other triggers, this is the branch or tag ref that triggered the workflow run.

We only want to push to S3 when merging to master. The current statement `if github.ref == 'refs/heads/master'` includes `pull_request_target` events for PRs against master.

### Bug Fixes
- user.yaml CI: Do not push to S3 for event 'pull_request_target'
