### PR TITLE
Add Coveralls to python_unit_test.yaml

### DIFF
--- a/.github/workflows/python_unit_test.yaml
+++ b/.github/workflows/python_unit_test.yaml
@@ -22,6 +22,10 @@ on:
         required: false
         default: '3.9'
         type: string
+      run-coveralls:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   run_tests:
@@ -105,3 +109,6 @@ jobs:
             # The hostname used to communicate with the PostgreSQL service container
             POSTGRES_HOST: localhost
             POSTGRES_PORT: 5432
+      - name: Submit Coveralls report
+        if: inputs.run-coveralls
+        uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Adding the command to push the coverage report, but not adding the coverage parameters to the default pytest function, because we would need to add an extra workflow parameter for the `--cov` value and i don't think it's necessary at the moment

### Improvements
- Add Coveralls to python_unit_test.yaml
