### PR TITLE
Fix/image name length

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -92,11 +92,11 @@ jobs:
             if [[ ${#IMAGE_TAG_NAME} -gt 63 ]]; then
                 echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
                 IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
-                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.\/]*)?[A-Za-z0-9])?$ ]]; then
                     echo "Image name validation passed"
                 else
-                    NEW_IMAGE_TAG_NAME=${IMAGE_TAG_NAME%?}0
-                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                    NEW_IMAGE_TAG_NAME=$(echo ${IMAGE_TAG_NAME%?}0)
+                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.\/]*)?[A-Za-z0-9])?$ ]]; then
                         echo "Image name ${IMAGE_TAG_NAME} violates validation, it will be changed to ${NEW_IMAGE_TAG_NAME}"
                         IMAGE_TAG_NAME=${NEW_IMAGE_TAG_NAME}
                     else
@@ -114,11 +114,11 @@ jobs:
             if [[ ${#IMAGE_TAG_NAME} -gt 63 ]]; then
                 echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
                 IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
-                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.\/]*)?[A-Za-z0-9])?$ ]]; then
                     echo "Image name validation passed"
                 else
-                    NEW_IMAGE_TAG_NAME=${IMAGE_TAG_NAME%?}0
-                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                    NEW_IMAGE_TAG_NAME=$(echo ${IMAGE_TAG_NAME%?}0)
+                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.\/]*)?[A-Za-z0-9])?$ ]]; then
                         echo "Image name ${IMAGE_TAG_NAME} violates validation, it will be changed to ${NEW_IMAGE_TAG_NAME}"
                         IMAGE_TAG_NAME=${NEW_IMAGE_TAG_NAME}
                     else

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -89,9 +89,21 @@ jobs:
           if [[ -z "${{ inputs.OVERRIDE_TAG_NAME }}" ]]
           then
             IMAGE_TAG_NAME=$(echo ${GITHUB_REF#refs/*/})
-            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]] ; then
+            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]]; then
                 echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
                 IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
+                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                    echo "Image name validation passed"
+                else
+                    NEW_IMAGE_TAG_NAME=${IMAGE_TAG_NAME%?}0
+                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                        echo "Image name ${IMAGE_TAG_NAME} violates validation, it will be changed to ${NEW_IMAGE_TAG_NAME}"
+                        IMAGE_TAG_NAME=${NEW_IMAGE_TAG_NAME}
+                    else
+                        echo "Image name ${IMAGE_TAG_NAME} violates validation and cannot be used"
+                        exit 1
+                    fi
+                fi
             fi
             echo "No OVERRIDE_TAG_NAME input provided, defaulting to current branch/tag name..."
             echo "IMAGE_TAG=$(echo ${IMAGE_TAG_NAME} | tr / _)"
@@ -99,9 +111,21 @@ jobs:
           else
             echo "OVERRIDE_TAG_NAME provided, using it for IMAGE_TAG..."
             IMAGE_TAG_NAME=$(echo ${{ inputs.OVERRIDE_TAG_NAME }})
-            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]] ; then
+            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]]; then
                 echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
                 IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
+                if [[ ${IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                    echo "Image name validation passed"
+                else
+                    NEW_IMAGE_TAG_NAME=${IMAGE_TAG_NAME%?}0
+                    if [[ ${NEW_IMAGE_TAG_NAME} =~ ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$ ]]; then
+                        echo "Image name ${IMAGE_TAG_NAME} violates validation, it will be changed to ${NEW_IMAGE_TAG_NAME}"
+                        IMAGE_TAG_NAME=${NEW_IMAGE_TAG_NAME}
+                    else
+                        echo "Image name ${IMAGE_TAG_NAME} violates validation and cannot be used"
+                        exit 1
+                    fi
+                fi
             fi
             echo "IMAGE_TAG=${IMAGE_TAG_NAME}"
             echo "IMAGE_TAG=${IMAGE_TAG_NAME}" >> $GITHUB_ENV

--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -88,13 +88,23 @@ jobs:
 
           if [[ -z "${{ inputs.OVERRIDE_TAG_NAME }}" ]]
           then
+            IMAGE_TAG_NAME=$(echo ${GITHUB_REF#refs/*/})
+            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]] ; then
+                echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
+                IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
+            fi
             echo "No OVERRIDE_TAG_NAME input provided, defaulting to current branch/tag name..."
-            echo "IMAGE_TAG=$(echo ${GITHUB_REF#refs/*/} | tr / _)"
-            echo "IMAGE_TAG=$(echo ${GITHUB_REF#refs/*/} | tr / _)" >> $GITHUB_ENV
+            echo "IMAGE_TAG=$(echo ${IMAGE_TAG_NAME} | tr / _)"
+            echo "IMAGE_TAG=$(echo ${IMAGE_TAG_NAME} | tr / _)" >> $GITHUB_ENV
           else
             echo "OVERRIDE_TAG_NAME provided, using it for IMAGE_TAG..."
-            echo "IMAGE_TAG=${{ inputs.OVERRIDE_TAG_NAME }}"
-            echo "IMAGE_TAG=${{ inputs.OVERRIDE_TAG_NAME }}" >> $GITHUB_ENV
+            IMAGE_TAG_NAME=$(echo ${{ inputs.OVERRIDE_TAG_NAME }})
+            if [[ ${#IMAGE_TAG_NAME} -gt 63 ]] ; then
+                echo "Image tag name is longer than 63 characters. It will be truncated to ${IMAGE_TAG_NAME:0:63}"
+                IMAGE_TAG_NAME=${IMAGE_TAG_NAME:0:63}
+            fi
+            echo "IMAGE_TAG=${IMAGE_TAG_NAME}"
+            echo "IMAGE_TAG=${IMAGE_TAG_NAME}" >> $GITHUB_ENV
           fi
 
           if [[ -z "${{ inputs.OVERRIDE_REPO_NAME }}" ]]


### PR DESCRIPTION
correctly format image tag name to have less than 63 characters and confirms to the format rules
tag/branch names longer than 63 character will be turncated, if the last character is non-alphanumeric it will be replaced by a `0`


### Improvements
- correctly format image tag name to have less than 63 characters and confirms to the format rules
