### PR TITLE
Validate markdown files

### DIFF
--- a/.github/workflows/validate_markdown.yaml
+++ b/.github/workflows/validate_markdown.yaml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Set up config files
       run: |
-        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/lint-md/.github/workflows/validate_markdown_lint.jsonc -P .github/workflows/
-        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/lint-md/.github/workflows/validate_markdown_links.json -P .github/workflows/
+        wget https://raw.githubusercontent.com/uc-cdis/.github/master/.github/workflows/validate_markdown_lint.jsonc -P .github/workflows/
+        wget https://raw.githubusercontent.com/uc-cdis/.github/master/.github/workflows/validate_markdown_links.json -P .github/workflows/
 
     - name: Check syntax
       uses: avto-dev/markdown-lint@v1.5.0

--- a/.github/workflows/validate_markdown.yaml
+++ b/.github/workflows/validate_markdown.yaml
@@ -1,0 +1,36 @@
+name: Markdown validation
+
+on:
+  workflow_call:
+    inputs:
+      SYNTAX_CHECK_IGNORE_FILES:
+        description: 'Multiple files must be separated with single space, eg "./one_file.md ./another_file.md"'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  markdown_validation:
+    name: Markdown validation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up config files
+      run: |
+        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/lint-md/.github/workflows/validate_markdown_lint.jsonc -P .github/workflows/
+        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/lint-md/.github/workflows/validate_markdown_links.json -P .github/workflows/
+
+    - name: Check syntax
+      uses: avto-dev/markdown-lint@v1.5.0
+      with:
+        config: '.github/workflows/validate_markdown_lint.jsonc'
+        args: '**.md'
+        ignore: ${{ inputs.SYNTAX_CHECK_IGNORE_FILES }}
+
+    - name: Check dead links
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+      with:
+        config-file: '.github/workflows/validate_markdown_links.json'
+        use-quiet-mode: 'yes'

--- a/.github/workflows/validate_markdown_links.json
+++ b/.github/workflows/validate_markdown_links.json
@@ -1,0 +1,9 @@
+{
+    "ignorePatterns": [
+        {
+            "description": "Ignore anchor links that currently cannot be resolved. See https://github.com/tcort/markdown-link-check/issues/225",
+            "pattern": "^#"
+        }
+    ],
+    "aliveStatusCodes": [200, 203, 206]
+}

--- a/.github/workflows/validate_markdown_lint.jsonc
+++ b/.github/workflows/validate_markdown_lint.jsonc
@@ -1,0 +1,12 @@
+{
+  "default": true, // Default state for all rules
+
+  "blanks-around-fences": false,
+  "blanks-around-lists": false,
+  "code-block-style": false,
+  "fenced-code-language": false,
+  "line-length": false,
+  "no-bare-urls": false,
+  "no-multiple-blanks": false,
+  "ul-style": false
+}


### PR DESCRIPTION
Complains about bad syntax (but we can disable rules we don't care about) and about dead links.
The config is centralized here so that we use consistent style across repos.

Uses https://github.com/marketplace/actions/markdown-linting-action and https://github.com/marketplace/actions/markdown-link-check

Surround a link with `<!-- markdown-link-check-disable -->` and `<!-- markdown-link-check-enable -->` to skip link validation

### New Features
- Reusable workflow for markdown file validation
