### PR TITLE
Update action.yml

### DIFF
--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -34,10 +34,10 @@ runs:
         go test ${{ inputs.TESTS_LOCATION }} -v -coverpkg=${{ inputs.TESTS_LOCATION }} -race -covermode atomic -coverprofile=${{ inputs.COVERAGE_PROFILE_OUTPUT_LOCATION }}
       shell: bash
     - name: Lint source code
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v5
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.51.2
+        version: v1.57
         # Optional: working directory, useful for monorepos
         # working-directory: somedir
         # Optional: golangci-lint command line arguments.


### PR DESCRIPTION

### Improvements
- golangci-lint for Go 1.21

### Dependency updates
- golangci-lint-action to 5
- golangci-lint to 1.57
