### PR TITLE
chore(deadlinks): adjust regex to catch anchor links but allow fragme…

### DIFF
--- a/.github/workflows/validate_markdown.yaml
+++ b/.github/workflows/validate_markdown.yaml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Set up config files
       run: |
-        wget https://raw.githubusercontent.com/uc-cdis/.github/master/.github/workflows/validate_markdown_lint.jsonc -P .github/workflows/
-        wget https://raw.githubusercontent.com/uc-cdis/.github/master/.github/workflows/validate_markdown_links.json -P .github/workflows/
+        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/deadlinks/.github/workflows/validate_markdown_lint.jsonc -P .github/workflows/
+        wget https://raw.githubusercontent.com/uc-cdis/.github/feat/deadlinks/.github/workflows/validate_markdown_links.json -P .github/workflows/
 
     - name: Check syntax
       uses: avto-dev/markdown-lint@v1.5.0

--- a/.github/workflows/validate_markdown_links.json
+++ b/.github/workflows/validate_markdown_links.json
@@ -2,7 +2,7 @@
     "ignorePatterns": [
         {
             "description": "Ignore anchor links that currently cannot be resolved. See https://github.com/tcort/markdown-link-check/issues/225",
-            "pattern": "^#"
+            "pattern": "^(?!http).+#.+"
         }
     ],
     "aliveStatusCodes": [200, 203, 206]

--- a/.github/workflows/validate_markdown_links.json
+++ b/.github/workflows/validate_markdown_links.json
@@ -2,7 +2,7 @@
     "ignorePatterns": [
         {
             "description": "Ignore anchor links that currently cannot be resolved. See https://github.com/tcort/markdown-link-check/issues/225",
-            "pattern": "^(?!http).?#.+"
+            "pattern": "^(?!http).*#.+"
         }
     ],
     "aliveStatusCodes": [200, 203, 206]

--- a/.github/workflows/validate_markdown_links.json
+++ b/.github/workflows/validate_markdown_links.json
@@ -2,7 +2,7 @@
     "ignorePatterns": [
         {
             "description": "Ignore anchor links that currently cannot be resolved. See https://github.com/tcort/markdown-link-check/issues/225",
-            "pattern": "^(?!http).+#.+"
+            "pattern": "^(?!http).?#.+"
         }
     ],
     "aliveStatusCodes": [200, 203, 206]


### PR DESCRIPTION
…nts in http(s) URLs

### New Features

### Breaking Changes

### Bug Fixes
- Markdown link checking now ignores anchor links with # but does NOT ignore URLs starting with `http` that might have fragments (which include `#`) 

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
