### PR TITLE
feat: update go action to newer version (and make 1.22 Go default)

### DIFF
--- a/.github/actions/golang-ci/action.yml
+++ b/.github/actions/golang-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   GO_VERSION:
     required: false
     type: string
-    default: "1.18"
+    default: "1.22"
   TESTS_LOCATION:
     required: false
     type: string
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: "${{ inputs.GO_VERSION }}"
     - name: Check out code
@@ -34,23 +34,11 @@ runs:
         go test ${{ inputs.TESTS_LOCATION }} -v -coverpkg=${{ inputs.TESTS_LOCATION }} -race -covermode atomic -coverprofile=${{ inputs.COVERAGE_PROFILE_OUTPUT_LOCATION }}
       shell: bash
     - name: Lint source code
-      uses: golangci/golangci-lint-action@v5
+      uses: golangci/golangci-lint-action@v6
       with:
-        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.57
-        # Optional: working directory, useful for monorepos
-        # working-directory: somedir
-        # Optional: golangci-lint command line arguments.
+        version: v1.59
         args: --timeout=5m
-        # Optional: show only new issues if it's a pull request. The default value is `false`.
-        # only-new-issues: true
-        # Optional: if set to true then the all caching functionality will be complete disabled,
-        #           takes precedence over all other caching options.
         skip-cache: true
-        # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-        # skip-pkg-cache: true
-        # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-        # skip-build-cache: true
     - name: Display lint results
       run: golangci-lint run
       if: always()


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: N/A

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
* use Go 1.22 as default (instead of Go 1.18, which is 1.5 years out-of-support)
* update GitHub Actions to latest, supported versions

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
