### PR TITLE
Pypi publish: PYPI_TEST_API_TOKEN not required

### DIFF
--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -72,6 +72,7 @@ jobs:
           PYPI_PROD_API_TOKEN: ${{ secrets.PYPI_PROD_API_TOKEN }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
+          echo $DO_TEST_PUBLISH_FIRST
           if [ "$DO_TEST_PUBLISH_FIRST" = "true" ]; then
             poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
           fi

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -36,7 +36,7 @@ on:
         type: boolean
     secrets:
       PYPI_TEST_API_TOKEN:
-        required: true
+        required: false
       PYPI_PROD_API_TOKEN:
         required: true
 jobs:
@@ -82,22 +82,22 @@ jobs:
           echo github.ref=${{ github.ref }}
         shell: bash
 
-      - name: Publish to Test PyPI
-        id: test-pypi
-        if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
-          poetry publish -n -vv -r testpypi
+      # - name: Publish to Test PyPI
+      #   id: test-pypi
+      #   if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
+      #   run: |
+      #     echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
+      #     poetry publish -n -vv -r testpypi
 
-      - name: Publish to PyPI
-        id: prod-pypi
-        if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "Since this is a tagged release, do a real publish"
-          poetry publish -n -vv
+      # - name: Publish to PyPI
+      #   id: prod-pypi
+      #   if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
+      #   run: |
+      #     echo "Since this is a tagged release, do a real publish"
+      #     poetry publish -n -vv
 
-      - name: If Publish to PyPI Did Not Succeed, Fail Job
-        if: ${{ steps.prod-pypi.outcome != 'success' }}
-        run: |
-          echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
-          exit 1
+      # - name: If Publish to PyPI Did Not Succeed, Fail Job
+      #   if: ${{ steps.prod-pypi.outcome != 'success' }}
+      #   run: |
+      #     echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
+      #     exit 1

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -84,22 +84,22 @@ jobs:
           echo github.ref=${{ github.ref }}
         shell: bash
 
-      # - name: Publish to Test PyPI
-      #   id: test-pypi
-      #   if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
-      #   run: |
-      #     echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
-      #     poetry publish -n -vv -r testpypi
+      - name: Publish to Test PyPI
+        id: test-pypi
+        if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
+          poetry publish -n -vv -r testpypi
 
-      # - name: Publish to PyPI
-      #   id: prod-pypi
-      #   if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
-      #   run: |
-      #     echo "Since this is a tagged release, do a real publish"
-      #     poetry publish -n -vv
+      - name: Publish to PyPI
+        id: prod-pypi
+        if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "Since this is a tagged release, do a real publish"
+          poetry publish -n -vv
 
-      # - name: If Publish to PyPI Did Not Succeed, Fail Job
-      #   if: ${{ steps.prod-pypi.outcome != 'success' }}
-      #   run: |
-      #     echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
-      #     exit 1
+      - name: If Publish to PyPI Did Not Succeed, Fail Job
+        if: ${{ steps.prod-pypi.outcome != 'success' }}
+        run: |
+          echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
+          exit 1

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -72,7 +72,7 @@ jobs:
           PYPI_PROD_API_TOKEN: ${{ secrets.PYPI_PROD_API_TOKEN }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          if [ -n "$PYPI_TEST_API_TOKEN" ]; then
+          if [ "$DO_TEST_PUBLISH_FIRST" = "true" ]; then
             poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
           fi
           poetry config pypi-token.pypi $PYPI_PROD_API_TOKEN
@@ -84,22 +84,22 @@ jobs:
           echo github.ref=${{ github.ref }}
         shell: bash
 
-      - name: Publish to Test PyPI
-        id: test-pypi
-        if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
-          poetry publish -n -vv -r testpypi
+      # - name: Publish to Test PyPI
+      #   id: test-pypi
+      #   if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
+      #   run: |
+      #     echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
+      #     poetry publish -n -vv -r testpypi
 
-      - name: Publish to PyPI
-        id: prod-pypi
-        if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "Since this is a tagged release, do a real publish"
-          poetry publish -n -vv
+      # - name: Publish to PyPI
+      #   id: prod-pypi
+      #   if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
+      #   run: |
+      #     echo "Since this is a tagged release, do a real publish"
+      #     poetry publish -n -vv
 
-      - name: If Publish to PyPI Did Not Succeed, Fail Job
-        if: ${{ steps.prod-pypi.outcome != 'success' }}
-        run: |
-          echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
-          exit 1
+      # - name: If Publish to PyPI Did Not Succeed, Fail Job
+      #   if: ${{ steps.prod-pypi.outcome != 'success' }}
+      #   run: |
+      #     echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
+      #     exit 1

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -88,22 +88,22 @@ jobs:
           echo github.ref=${{ github.ref }}
         shell: bash
 
-      # - name: Publish to Test PyPI
-      #   id: test-pypi
-      #   if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
-      #   run: |
-      #     echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
-      #     poetry publish -n -vv -r testpypi
+      - name: Publish to Test PyPI
+        id: test-pypi
+        if: ${{ inputs.DO_TEST_PUBLISH_FIRST && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "Attempting a test publish before a real one. Note that a real one will only trigger on tags"
+          poetry publish -n -vv -r testpypi
 
-      # - name: Publish to PyPI
-      #   id: prod-pypi
-      #   if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
-      #   run: |
-      #     echo "Since this is a tagged release, do a real publish"
-      #     poetry publish -n -vv
+      - name: Publish to PyPI
+        id: prod-pypi
+        if: ${{ (!inputs.DO_TEST_PUBLISH_FIRST || (inputs.DO_TEST_PUBLISH_FIRST && steps.test-pypi.outcome == 'success')) && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "Since this is a tagged release, do a real publish"
+          poetry publish -n -vv
 
-      # - name: If Publish to PyPI Did Not Succeed, Fail Job
-      #   if: ${{ steps.prod-pypi.outcome != 'success' }}
-      #   run: |
-      #     echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
+      - name: If Publish to PyPI Did Not Succeed, Fail Job
+        if: ${{ steps.prod-pypi.outcome != 'success' }}
+        run: |
+          echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
       #     exit 1

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -66,16 +66,19 @@ jobs:
           poetry show -vv
         shell: bash
 
-      - name: Configure PyPI Repos in Poetry and Poetry Build
+      - name: Configure Test PyPI Repo
+        if: ${{ inputs.DO_TEST_PUBLISH_FIRST }}
         env:
           PYPI_TEST_API_TOKEN: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        run: |
+          poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
+        shell: bash
+
+      - name: Configure Prod PyPI Repo and Poetry Build
+        env:
           PYPI_PROD_API_TOKEN: ${{ secrets.PYPI_PROD_API_TOKEN }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          echo $DO_TEST_PUBLISH_FIRST
-          if [ "$DO_TEST_PUBLISH_FIRST" = "true" ]; then
-            poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
-          fi
           poetry config pypi-token.pypi $PYPI_PROD_API_TOKEN
           poetry build
         shell: bash

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -72,7 +72,7 @@ jobs:
           PYPI_PROD_API_TOKEN: ${{ secrets.PYPI_PROD_API_TOKEN }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          if [ -z "$PYPI_TEST_API_TOKEN" ]; then
+          if [ -n "$PYPI_TEST_API_TOKEN" ]; then
             poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
           fi
           poetry config pypi-token.pypi $PYPI_PROD_API_TOKEN

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -72,7 +72,9 @@ jobs:
           PYPI_PROD_API_TOKEN: ${{ secrets.PYPI_PROD_API_TOKEN }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
+          if [ -z "$PYPI_TEST_API_TOKEN" ]; then
+            poetry config pypi-token.testpypi $PYPI_TEST_API_TOKEN
+          fi
           poetry config pypi-token.pypi $PYPI_PROD_API_TOKEN
           poetry build
         shell: bash

--- a/.github/workflows/python_package_index_publish.yaml
+++ b/.github/workflows/python_package_index_publish.yaml
@@ -106,4 +106,4 @@ jobs:
         if: ${{ steps.prod-pypi.outcome != 'success' }}
         run: |
           echo "Since this is a tagged release, and the real publish failed or didn't run, fail the job"
-      #     exit 1
+          exit 1


### PR DESCRIPTION
tested [here](https://github.com/uc-cdis/gen3utils/commit/d3aefb6adeb25d926b63e556a0e3c61bd0e51d37), [here](https://github.com/uc-cdis/gen3utils/commit/78b68189398696088b922d622f68dac8d378a672) and [here](https://github.com/uc-cdis/gen3utils/commit/7a47ec5d30ea1d94193a518eb592961e36d9e183)

### Improvements
- Pypi publish: `PYPI_TEST_API_TOKEN` not required when `DO_TEST_PUBLISH_FIRST` is false
