### PR TITLE
Fix/poetry remove gdcdictionary

### DIFF
--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -62,7 +62,7 @@ jobs:
         poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
-        git clone https://github.com/uc-cdis/dictionaryutils
+        git clone --branch 3.4.10 https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
     - name: Attempt poetry or pip re-install of dictionary as `gdcdictionary`

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -65,6 +65,8 @@ jobs:
         git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
+        echo "Removing 'gdcdictionary' and re-installing in following step"
+        poetry remove gdcdictionary
     - name: Attempt poetry or pip re-install of dictionary as `gdcdictionary`
       # install via pip or poetry conditionally
       run: |

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -62,7 +62,7 @@ jobs:
         poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
-        git clone https://github.com/uc-cdis/dictionaryutils
+        git clone --branch fix/remove-gen3dictionary-uninstall https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
         echo "Removing 'gdcdictionary' and re-installing in following step"

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -65,8 +65,6 @@ jobs:
         git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
-        echo "Removing 'gdcdictionary' and re-installing in following step"
-        poetry remove gdcdictionary
     - name: Attempt poetry or pip re-install of dictionary as `gdcdictionary`
       # install via pip or poetry conditionally
       run: |

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -72,7 +72,8 @@ jobs:
       run: |
         echo "installing the dictionary as 'gdcdictionary'"
         if [ -f setup.py ]; then
-          pip install -e .
+          cd dictionaryutils
+          pip install -e ..
         fi
         if [ -f pyproject.toml ]; then
           poetry install -vv --all-extras --no-interaction || true
@@ -86,6 +87,8 @@ jobs:
         echo "dependencies after run_test"
         poetry show
         aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
+        echo "Schema dir for artifact: "
+        python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DICT_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.DICT_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -62,18 +62,21 @@ jobs:
         poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
-        git clone --branch 3.4.10 https://github.com/uc-cdis/dictionaryutils
+        git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
+        echo "Removing 'gdcdictionary' and re-installing in following step"
+        poetry remove gdcdictionary
     - name: Attempt poetry or pip re-install of dictionary as `gdcdictionary`
       # install via pip or poetry conditionally
       run: |
         echo "installing the dictionary as 'gdcdictionary'"
         if [ -f setup.py ]; then
-          cd dictionaryutils
-          pip install -e ..
+          echo "Install via pip"
+          pip install .
         fi
         if [ -f pyproject.toml ]; then
+          echo "Install via poetry"
           poetry install -vv --all-extras --no-interaction || true
         fi
     - name: Run dictionary tests, dump schema, and move to S3

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -62,7 +62,7 @@ jobs:
         poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
-        git clone --branch fix/remove-gen3dictionary-uninstall https://github.com/uc-cdis/dictionaryutils
+        git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
         echo "Removing 'gdcdictionary' and re-installing in following step"


### PR DESCRIPTION
In this PR the package removals and re-installs are migrated out of the `dictionaryutils/run_tests.sh` script and handled here in the `dictionary_push.yaml` workflow.

* A step to remove `gdcdictionary` is inserted after the install of `dictionaryutils`. 
* The `-e` flag is removed from the pip install of `gdcdictionary` in the parent directory. 

The previous PR was removing `gdcdictionary` from `env/lib` but not from `env/src` in the github workflow. In this fix we also use poetry to remove from `env/src`. We then re-install, but now into `env/lib`.

### New Features

### Breaking Changes

### Bug Fixes
* Additional removal of gdcdictionary before re-install
* Removed the `-e` flag from the re-installs of gdcdictionary to install in `env/lib`

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
