### PR TITLE
Fix/pip reinstall gdcddictionary

### DIFF
--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -81,7 +81,7 @@ jobs:
                   ]
               },
           )
-          EOT
+        EOT
 
           rm pyproject.toml
           rm poetry.lock

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -71,26 +71,25 @@ jobs:
         if [ -f pyproject.toml ]; then
           cd dictionaryutils
           echo "Removing 'gen3dictionary' via pip"
-          pip uninstall -y gen3dictionary
-          pip uninstall -y gdcdictionary
+          poetry run pip uninstall -y gen3dictionary
+          poetry run pip uninstall -y gdcdictionary
         elif [ -f setup.py ]; then
           cd dictionaryutils
           echo "Removing 'gdcdictionary' via poetry"
           poetry remove gdcdictionary
-          pip uninstall -y gen3dictionary
+          poetry run pip uninstall -y gen3dictionary
         fi
     - name: Attempt re-install of dictionary as `gdcdictionary`
       run: |
         echo "Re-installing the dictionary as 'gdcdictionary'"
         if [ -f pyproject.toml ]; then
-          echo "via poetry"
-          poetry install -vv --all-extras --no-interaction || true
-          echo "Poetry show after install"
-          poetry show
+          echo "via pip"
+          cd dictionaryutils
+          poetry run pip install ..
         elif [ -f setup.py ]; then
           echo "via pip"
           cd dictionaryutils
-          pip install ..
+          poetry run pip install ..
         fi
 
     - name: Run dictionary tests, dump schema, and move to S3

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -2,22 +2,25 @@ name: Test and deploy dictionaries
 
 # OVERVIEW
 #
-# The `dictionaryutils` package is used for dumping the schemas from the parent dictionary repo.
+# The `dictionaryutils` package is used for dumping the schemas from the
+# parent dictionary repo.
 # Dependencies on both `gen3dictionary` and `gdcdictionary`
 # cause conflict in importing the correct `SCHEMA_DIR` used for dumping schemas.
 #
+# The purpose of this script is to arrange that dumped schemas are from
+# the parent dictionary repo and are not from those installed by dictionaryutils.
+#
 # There are two steps to ensure setting the correct source:
-#  - uninstall `gen3dictionary` after the dictionaryutils install.
+#  - uninstall `gen3dictionary` and `gdcdictionary` after the dictionaryutils install.
 #  - Re-install the dictionary in the parent repo as `gdcdictionary`
 #
-# In order to ensure the correct virtual env usage and
-# compatibility with both pyproject.yaml and setup.py for the dictionary repos, we
-# conditionally select `poetry` or `pip` when installing the dictionary as `gdcdictionary`,
-#
 # Then the `run_tests.sh` script will:
-#    - uninstall `gen3dictionary`
-#    - run the dictionary tests from dictionaryutils which expects `gdcdictionary` library as the unit to test
-#    - run the dump schemas to move it to the /artifacts folder
+#   - run the dictionary tests from dictionaryutils which expects `gdcdictionary`
+#     library as the unit to test
+#   - run the dump schemas to move it to the /artifacts folder
+#
+# All commands should be run under `poetry run` to ensure that changes take
+# place in the poetry virtual env.
 
 on:
   workflow_call:
@@ -101,12 +104,10 @@ jobs:
         poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"
         ls `poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
-
         echo "Run tests under poetry"
         poetry run ./run_tests.sh
         echo "Number of schemas in artifact"
         grep -o ".yaml\"" artifacts/schema.json | wc -l
-
         # Temporarily disable s3 copy
         # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
 

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -77,6 +77,7 @@ jobs:
           cd dictionaryutils
           echo "Removing 'gen3dictionary' via pip"
           pip uninstall -y gen3dictionary
+          pip uninstall -y gdcdictionary
         fi
     - name: Attempt pip re-install of dictionary as `gdcdictionary`
       run: |
@@ -86,11 +87,9 @@ jobs:
           pip install .
         fi
         if [ -f pyproject.toml ]; then
-          echo "via poetry"
-          pip install .
-          poetry install -vv --all-extras --no-interaction
+          echo "via pip in dictionaryutils"
           cd dictionaryutils
-          poetry install --without dev
+          pip install ..
         fi
     - name: Run dictionary tests, dump schema, and move to S3
       run: |

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -56,37 +56,10 @@ jobs:
         pip install --upgrade pip
         curl -sSL https://install.python-poetry.org | python -
         pip list
-    - name: Create setup.py if we have a pyproject.toml
-      # Force parent to use setup.py like openaccess_dictionary
+    - name: Attempt poetry install of dictionary as `gdcdictionary`
+      # this will only work when the dictionary is using a poetry setup with pyproject.toml
       run: |
-        if [ -f pyproject.toml ]; then
-        cat <<EOT >> setup.py
-        from setuptools import setup, find_packages
-
-        setup(
-            name='gdcdictionary',
-            version='0.0.0',
-            packages=find_packages(),
-            install_requires=[
-                'dictionaryutils',
-            ],
-            dependency_links=[
-              "git+https://github.com/uc-cdis/dictionaryutils.git@1.2.0#egg=dictionaryutils",
-            ],
-            package_data={
-                "gdcdictionary": [
-                    "schemas/*.yaml",
-                    "schemas/projects/*.yaml",
-                    "schemas/projects/*/*.yaml",
-                ]
-            },
-        )
-        EOT
-
-          rm pyproject.toml
-          rm poetry.lock
-
-        fi
+        poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
         git clone https://github.com/uc-cdis/dictionaryutils
@@ -95,63 +68,42 @@ jobs:
     - name: Uninstall gdcdictionary
       # remove gdcdictionary or gen3dictionary conditionally
       run: |
-        if [ -f setup.py ]; then
-          cd dictionaryutils
-          echo "Removing 'gdcdictionary' via poetry"
-          poetry remove gdcdictionary
-          pip uninstall -y gen3dictionary
-          cd ..
-        fi
         if [ -f pyproject.toml ]; then
           cd dictionaryutils
           echo "Removing 'gen3dictionary' via pip"
           pip uninstall -y gen3dictionary
-          pip uninstall -y gdcdictionary
+        elif [ -f setup.py ]; then
+          cd dictionaryutils
+          echo "Removing 'gdcdictionary' via poetry"
+          poetry remove gdcdictionary
+          pip uninstall -y gen3dictionary
         fi
-    - name: Attempt pip re-install of dictionary as `gdcdictionary`
+    - name: Attempt re-install of dictionary as `gdcdictionary`
       run: |
         echo "Re-installing the dictionary as 'gdcdictionary'"
-        if [ -f setup.py ]; then
+        if [ -f pyproject.toml ]; then
+          echo "via poetry"
+          poetry install -vv --all-extras --no-interaction || true
+          echo "Poetry show after install"
+          poetry show
+        elif [ -f setup.py ]; then
           echo "via pip"
           cd dictionaryutils
           pip install ..
         fi
-        if [ -f pyproject.toml ]; then
-          echo "via pip in dictionaryutils"
-          cd dictionaryutils
-          pip install ..
-        fi
+
     - name: Run dictionary tests, dump schema, and move to S3
       run: |
         cd dictionaryutils
         echo "dependencies before run_test"
         poetry show
         echo "Schema dir for artifact"
-        python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
-        echo "Schemas"
-        ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
-        echo "Schema dir under poetry"
         poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"
         ls `poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
 
         echo "Run tests under poetry"
         poetry run ./run_tests.sh
-        echo "Number of schemas in artifact"
-        grep -o ".yaml\"" artifacts/schema.json | wc -l
-
-        # echo "Run tests directly"
-        # bash ./run_tests.sh
-        # echo "Number of schemas in artifact"
-        # grep -o ".yaml\"" artifacts/schema.json | wc -l
-
-        echo "Create artifact under poetry"
-        poetry run python bin/dump_schema.py
-        echo "Number of schemas in artifact"
-        grep -o ".yaml\"" artifacts/schema.json | wc -l
-
-        echo "Create artifact directly"
-        python bin/dump_schema.py
         echo "Number of schemas in artifact"
         grep -o ".yaml\"" artifacts/schema.json | wc -l
 

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -93,13 +93,12 @@ jobs:
     - name: Run dictionary tests, dump schema, and move to S3
       run: |
         cd dictionaryutils
+        echo "dependencies before run_test"
+        poetry show
         echo "Schema dir for artifact"
         python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"
         ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
-
-        echo "dependencies before run_test"
-        poetry show
         poetry run ./run_tests.sh
         # Temporarily disable the S3 copy for testing
         # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -72,6 +72,7 @@ jobs:
           cd dictionaryutils
           echo "Removing 'gen3dictionary' via pip"
           pip uninstall -y gen3dictionary
+          pip uninstall -y gdcdictionary
         elif [ -f setup.py ]; then
           cd dictionaryutils
           echo "Removing 'gdcdictionary' via poetry"

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -101,8 +101,7 @@ jobs:
         poetry run ./run_tests.sh
         echo "Number of schemas in artifact"
         grep -o ".yaml\"" artifacts/schema.json | wc -l
-        # Temporarily disable s3 copy
-        # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
+        aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
 
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DICT_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -7,8 +7,9 @@ name: Test and deploy dictionaries
 # Dependencies on both `gen3dictionary` and `gdcdictionary`
 # cause conflict in importing the correct `SCHEMA_DIR` used for dumping schemas.
 #
-# The purpose of this script is to arrange that dumped schemas are from
-# the parent dictionary repo and are not from those installed by dictionaryutils.
+# The purpose of this workflow is to set up a virtual environment where dumped
+# schemas are from the parent dictionary repo and are not from those
+# installed by dictionaryutils.
 #
 # There are two steps to ensure setting the correct source:
 #  - uninstall `gen3dictionary` and `gdcdictionary` after the dictionaryutils install.
@@ -85,16 +86,8 @@ jobs:
     - name: Attempt re-install of dictionary as `gdcdictionary`
       run: |
         echo "Re-installing the dictionary as 'gdcdictionary'"
-        if [ -f pyproject.toml ]; then
-          echo "via pip"
-          cd dictionaryutils
-          poetry run pip install ..
-        elif [ -f setup.py ]; then
-          echo "via pip"
-          cd dictionaryutils
-          poetry run pip install ..
-        fi
-
+        cd dictionaryutils
+        poetry run pip install ..
     - name: Run dictionary tests, dump schema, and move to S3
       run: |
         cd dictionaryutils

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -65,31 +65,36 @@ jobs:
         git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
         poetry install -vv --all-extras --no-interaction
-        echo "Removing 'gdcdictionary' and re-installing in following step"
-        poetry remove gdcdictionary
-    - name: Attempt poetry or pip re-install of dictionary as `gdcdictionary`
-      # install via pip or poetry conditionally
+    - name: Uninstall gdcdictionary
+      # remove gdcdictionary or gen3dictionary conditionally
       run: |
-        echo "installing the dictionary as 'gdcdictionary'"
         if [ -f setup.py ]; then
-          echo "Install via pip"
-          pip install .
+          cd dictionaryutils
+          echo "Removing 'gdcdictionary' via poetry"
+          poetry remove gdcdictionary
         fi
         if [ -f pyproject.toml ]; then
-          echo "Install via poetry"
-          poetry install -vv --all-extras --no-interaction || true
+          cd dictionaryutils
+          echo "Removing 'gen3dictionary' via pip"
+          pip uninstall -y gen3dictionary
         fi
+    - name: Attempt pip re-install of dictionary as `gdcdictionary`
+      run: |
+        echo "Re-installing the dictionary as 'gdcdictionary'"
+        pip install .
+        echo "Schema dir for artifact"
+        python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
+        echo "Schemas"
+        ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
     - name: Run dictionary tests, dump schema, and move to S3
       run: |
         cd dictionaryutils
         echo "dependencies before run_test"
         poetry show
         poetry run ./run_tests.sh
-        echo "dependencies after run_test"
-        poetry show
-        aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
-        echo "Schema dir for artifact: "
-        python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
+        # Temporarily disable the S3 copy for testing
+        # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
+
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DICT_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.DICT_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -64,6 +64,8 @@ jobs:
       run: |
         git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
+        sed -i 's/\, develop = true//' pyproject.toml
+        rm poetry.lock
         poetry install -vv --all-extras --no-interaction
     - name: Uninstall gdcdictionary
       # remove gdcdictionary or gen3dictionary conditionally

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -74,6 +74,7 @@ jobs:
           cd dictionaryutils
           echo "Removing 'gdcdictionary' via poetry"
           poetry remove gdcdictionary
+          cd ..
         fi
         if [ -f pyproject.toml ]; then
           cd dictionaryutils

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -81,7 +81,14 @@ jobs:
     - name: Attempt pip re-install of dictionary as `gdcdictionary`
       run: |
         echo "Re-installing the dictionary as 'gdcdictionary'"
-        pip install .
+        if [ -f setup.py ]; then
+          echo "via pip"
+          pip install .
+        fi
+        if [ -f pyproject.toml ]; then
+          echo "via poetry"
+          poetry install -vv --all-extras --no-interaction
+        fi
         echo "Schema dir for artifact"
         python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -89,13 +89,14 @@ jobs:
           echo "via poetry"
           poetry install -vv --all-extras --no-interaction
         fi
+    - name: Run dictionary tests, dump schema, and move to S3
+      run: |
+        cd dictionaryutils
         echo "Schema dir for artifact"
         python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"
         ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
-    - name: Run dictionary tests, dump schema, and move to S3
-      run: |
-        cd dictionaryutils
+
         echo "dependencies before run_test"
         poetry show
         poetry run ./run_tests.sh

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -130,8 +130,25 @@ jobs:
         python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
         echo "Schemas"
         ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
+        echo "Schema dir under poetry"
+        poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
+
         poetry run ./run_tests.sh
-        aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
+        echo "Number of schemas in artifact"
+        grep -o ".yaml\"" artifacts/schema.json | wc -l
+
+        echo "Create artifact under poetry"
+        poetry run python bin/dump_schema.py
+        echo "Number of schemas in artifact"
+        grep -o ".yaml\"" artifacts/schema.json | wc -l
+
+        echo "Create artifact directly"
+        python bin/dump_schema.py
+        echo "Number of schemas in artifact"
+        grep -o ".yaml\"" artifacts/schema.json | wc -l
+
+        # Temporarily disable s3 copy
+        # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
 
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DICT_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -132,16 +132,18 @@ jobs:
         ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
         echo "Schema dir under poetry"
         poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
+        echo "Schemas"
+        ls `poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
 
         echo "Run tests under poetry"
         poetry run ./run_tests.sh
         echo "Number of schemas in artifact"
         grep -o ".yaml\"" artifacts/schema.json | wc -l
 
-        echo "Run tests directly"
-        bash ./run_tests.sh
-        echo "Number of schemas in artifact"
-        grep -o ".yaml\"" artifacts/schema.json | wc -l
+        # echo "Run tests directly"
+        # bash ./run_tests.sh
+        # echo "Number of schemas in artifact"
+        # grep -o ".yaml\"" artifacts/schema.json | wc -l
 
         echo "Create artifact under poetry"
         poetry run python bin/dump_schema.py

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -56,7 +56,7 @@ jobs:
         pip install --upgrade pip
         curl -sSL https://install.python-poetry.org | python -
         pip list
-    - name: Attempt poetry install of dictionary as `gdcdictionary`
+    - name: Create setup.py if we have a pyproject.toml
       # Force parent to use setup.py like openaccess_dictionary
       run: |
         if [ -f pyproject.toml ]; then
@@ -87,9 +87,6 @@ jobs:
           rm poetry.lock
 
         fi
-        echo "Setup file"
-        cat setup.py
-        # poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
         git clone https://github.com/uc-cdis/dictionaryutils
@@ -134,8 +131,7 @@ jobs:
         echo "Schemas"
         ls `python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"`
         poetry run ./run_tests.sh
-        # Temporarily disable the S3 copy for testing
-        # aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
+        aws s3 cp artifacts/schema.json s3://${{ inputs.BUCKET }}/${{ inputs.DIRECTORY }}/$GITHUB_REF_NAME/schema.json --region ${{ inputs.REGION }}
 
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DICT_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -57,15 +57,43 @@ jobs:
         curl -sSL https://install.python-poetry.org | python -
         pip list
     - name: Attempt poetry install of dictionary as `gdcdictionary`
-      # this will only work when the dictionary is using a poetry setup with pyproject.toml
+      # Force parent to use setup.py like openaccess_dictionary
       run: |
-        poetry install -vv --all-extras --no-interaction || true
+        if [ -f pyproject.toml ]; then
+          cat <<EOT >> setup.py
+          from setuptools import setup, find_packages
+
+          setup(
+              name='gdcdictionary',
+              version='0.0.0',
+              packages=find_packages(),
+              install_requires=[
+                  'dictionaryutils',
+              ],
+              dependency_links=[
+                "git+https://github.com/uc-cdis/dictionaryutils.git@1.2.0#egg=dictionaryutils",
+              ],
+              package_data={
+                  "gdcdictionary": [
+                      "schemas/*.yaml",
+                      "schemas/projects/*.yaml",
+                      "schemas/projects/*/*.yaml",
+                  ]
+              },
+          )
+          EOT
+
+          rm pyproject.toml
+          rm poetry.lock
+
+        fi
+        echo "Setup file"
+        cat setup.py
+        # poetry install -vv --all-extras --no-interaction || true
     - name: Get dictionaryutils library and install
       run: |
         git clone https://github.com/uc-cdis/dictionaryutils
         cd dictionaryutils
-        sed -i 's/\, develop = true//' pyproject.toml
-        rm poetry.lock
         poetry install -vv --all-extras --no-interaction
     - name: Uninstall gdcdictionary
       # remove gdcdictionary or gen3dictionary conditionally
@@ -74,6 +102,7 @@ jobs:
           cd dictionaryutils
           echo "Removing 'gdcdictionary' via poetry"
           poetry remove gdcdictionary
+          pip uninstall -y gen3dictionary
           cd ..
         fi
         if [ -f pyproject.toml ]; then
@@ -87,7 +116,8 @@ jobs:
         echo "Re-installing the dictionary as 'gdcdictionary'"
         if [ -f setup.py ]; then
           echo "via pip"
-          pip install .
+          cd dictionaryutils
+          pip install ..
         fi
         if [ -f pyproject.toml ]; then
           echo "via pip in dictionaryutils"

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -133,7 +133,13 @@ jobs:
         echo "Schema dir under poetry"
         poetry run python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)"
 
+        echo "Run tests under poetry"
         poetry run ./run_tests.sh
+        echo "Number of schemas in artifact"
+        grep -o ".yaml\"" artifacts/schema.json | wc -l
+
+        echo "Run tests directly"
+        bash ./run_tests.sh
         echo "Number of schemas in artifact"
         grep -o ".yaml\"" artifacts/schema.json | wc -l
 

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -7,8 +7,8 @@ name: Test and deploy dictionaries
 # cause conflict in importing the correct `SCHEMA_DIR` used for dumping schemas.
 #
 # There are two steps to ensure setting the correct source:
-#  - Re-install the dictionary in the parent repo as `gdcdictionary` after the install of `dictionaryutils`
-#  - uninstall `gen3dictionary` as part of the `run_test.sh` script.
+#  - uninstall `gen3dictionary` after the dictionaryutils install.
+#  - Re-install the dictionary in the parent repo as `gdcdictionary`
 #
 # In order to ensure the correct virtual env usage and
 # compatibility with both pyproject.yaml and setup.py for the dictionary repos, we
@@ -87,6 +87,7 @@ jobs:
         fi
         if [ -f pyproject.toml ]; then
           echo "via poetry"
+          pip install .
           poetry install -vv --all-extras --no-interaction
         fi
     - name: Run dictionary tests, dump schema, and move to S3

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -90,7 +90,7 @@ jobs:
           pip install .
           poetry install -vv --all-extras --no-interaction
           cd dictionaryutils
-          poetry install --without-dev
+          poetry install --without dev
         fi
     - name: Run dictionary tests, dump schema, and move to S3
       run: |

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -89,6 +89,8 @@ jobs:
           echo "via poetry"
           pip install .
           poetry install -vv --all-extras --no-interaction
+          cd dictionaryutils
+          poetry install --without-dev
         fi
     - name: Run dictionary tests, dump schema, and move to S3
       run: |

--- a/.github/workflows/dictionary_push.yaml
+++ b/.github/workflows/dictionary_push.yaml
@@ -60,27 +60,27 @@ jobs:
       # Force parent to use setup.py like openaccess_dictionary
       run: |
         if [ -f pyproject.toml ]; then
-          cat <<EOT >> setup.py
-          from setuptools import setup, find_packages
+        cat <<EOT >> setup.py
+        from setuptools import setup, find_packages
 
-          setup(
-              name='gdcdictionary',
-              version='0.0.0',
-              packages=find_packages(),
-              install_requires=[
-                  'dictionaryutils',
-              ],
-              dependency_links=[
-                "git+https://github.com/uc-cdis/dictionaryutils.git@1.2.0#egg=dictionaryutils",
-              ],
-              package_data={
-                  "gdcdictionary": [
-                      "schemas/*.yaml",
-                      "schemas/projects/*.yaml",
-                      "schemas/projects/*/*.yaml",
-                  ]
-              },
-          )
+        setup(
+            name='gdcdictionary',
+            version='0.0.0',
+            packages=find_packages(),
+            install_requires=[
+                'dictionaryutils',
+            ],
+            dependency_links=[
+              "git+https://github.com/uc-cdis/dictionaryutils.git@1.2.0#egg=dictionaryutils",
+            ],
+            package_data={
+                "gdcdictionary": [
+                    "schemas/*.yaml",
+                    "schemas/projects/*.yaml",
+                    "schemas/projects/*/*.yaml",
+                ]
+            },
+        )
         EOT
 
           rm pyproject.toml


### PR DESCRIPTION
This PR updates the dictionary_build to consistently run all commands under poetry. The intent is to ensure the correct `SOURCE_DIR` is selected. Additional logging statements show which schemas are written to the artifact.  

### New Features

### Breaking Changes

### Bug Fixes

* Use poetry environment to get correct SOURCE_DIR for creating schema artifact.

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
