### PR TITLE
fix(timeout-minutes): put timeout-minutes on the job definition

### DIFF
--- a/.github/workflows/snykcli.yaml
+++ b/.github/workflows/snykcli.yaml
@@ -1,9 +1,9 @@
 name: SnykCLI for Poetry
 on: [workflow_call]
-timeout-minutes: 15
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
seeing errors like so: https://github.com/uc-cdis/docker-bitnami-pgvector/actions/runs/27029218539

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
Fix a syntax error on timeout-minutes in synkcli job.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
