### PR TITLE
fix(logic): dont login to ECR if quay only

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -68,6 +68,7 @@ jobs:
 
       # https://github.com/docker/login-action#aws-public-elastic-container-registry-ecr
       - name: Login to ECR
+        if: ${{ !inputs.USE_QUAY_ONLY }}
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.AWS_ECR_REGISTRY }}
@@ -124,7 +125,7 @@ jobs:
             quay.io/cdis/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
             ${{ inputs.AWS_ECR_REGISTRY }}/gen3/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
 
-      - name: Build and push
+      - name: Build and push ECR
         if: ${{ !inputs.USE_QUAY_ONLY }}
         uses: docker/build-push-action@v6
         # You may get ECR-push errors when first adding the workflow to a github repo.
@@ -143,8 +144,7 @@ jobs:
           platforms: ${{ inputs.BUILD_PLATFORMS }}
           build-args: ${{ inputs.BUILD_ARGS }}
 
-      - name: Build and push (Quay only)
-        if: ${{ inputs.USE_QUAY_ONLY }}
+      - name: Build and push Quay
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.DOCKERFILE_BUILD_CONTEXT }}


### PR DESCRIPTION
Link to JIRA ticket if there is one:
Uncovered while working through [pgvector docker image](https://ctds-planx.atlassian.net/browse/GPE-2406)
### New Features

### Breaking Changes

### Bug Fixes
Looks like the native one had this right but doesn't have build args for my dockerfile. So fixing here. 
- quay only had to be true to get onto quay true. This isn't true in the build_native
- don't login to ECR if quay only, no need.

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
